### PR TITLE
Implement basic rename-based cache switching

### DIFF
--- a/assets/js/serverselector.js
+++ b/assets/js/serverselector.js
@@ -95,7 +95,36 @@ function loadServerList() {
 function setGameInfo(serverUUID) {
   var result = serverarray.filter(function(obj) {return (obj.uuid === serverUUID);})[0];
   var gameversion = versionarray.filter(function(obj) {return (obj.name === result.version);})[0];
-  window.asseturl = gameversion.url // gameclient.js needs to access this
+  
+  // Cache folder renaming
+  var cachedir = userdir + '\\..\\..\\LocalLow\\Unity\\Web Player\\Cache';
+  var curversion = cachedir + '\\Fusionfall';
+  var newversion = cachedir + '\\' + gameversion.name;
+
+  if (remotefs.existsSync(curversion)) {
+    // cache already exists
+    // find out what version it belongs to
+    if (remotefs.existsSync(userdir + '\\lastver')) {
+      var lastversion = remotefs.readFileSync(userdir + '\\lastver');
+      remotefs.renameSync(curversion, cachedir + '\\' + lastversion);
+      console.log('Cached version ' + lastversion);
+    } else {
+      console.log(
+        "Couldn't find last version record; cache will get overwritten"
+      );
+    }
+  }
+
+  if (remotefs.existsSync(newversion)) {
+    // rename saved cache to FusionFall
+    remotefs.renameSync(newversion, curversion);
+    console.log('Loaded cached ' + gameversion.name);
+  }
+
+  // make note of what version we are launching for next launch
+  remotefs.writeFileSync(userdir + '\\lastver', gameversion.name);
+
+  window.asseturl = gameversion.url; // gameclient.js needs to access this
 
   remotefs.writeFileSync(__dirname+"\\assetInfo.php", asseturl);
   remotefs.writeFileSync(__dirname+"\\loginInfo.php", result.ip);

--- a/assets/js/serverselector.js
+++ b/assets/js/serverselector.js
@@ -111,7 +111,7 @@ function setGameInfo(serverUUID) {
       console.log('Cached version ' + lastversion);
     } else {
       console.log(
-        "Couldn't find last version record; cache will get overwritten"
+        "Couldn't find last version record; cache may get overwritten"
       );
     }
   }

--- a/assets/js/serverselector.js
+++ b/assets/js/serverselector.js
@@ -100,12 +100,13 @@ function setGameInfo(serverUUID) {
   var cachedir = userdir + '\\..\\..\\LocalLow\\Unity\\Web Player\\Cache';
   var curversion = cachedir + '\\Fusionfall';
   var newversion = cachedir + '\\' + gameversion.name;
+  var record = userdir + '\\.lastver';
 
   if (remotefs.existsSync(curversion)) {
     // cache already exists
     // find out what version it belongs to
-    if (remotefs.existsSync(userdir + '\\lastver')) {
-      var lastversion = remotefs.readFileSync(userdir + '\\lastver');
+    if (remotefs.existsSync(record)) {
+      var lastversion = remotefs.readFileSync(record);
       remotefs.renameSync(curversion, cachedir + '\\' + lastversion);
       console.log('Cached version ' + lastversion);
     } else {
@@ -122,7 +123,7 @@ function setGameInfo(serverUUID) {
   }
 
   // make note of what version we are launching for next launch
-  remotefs.writeFileSync(userdir + '\\lastver', gameversion.name);
+  remotefs.writeFileSync(record, gameversion.name);
 
   window.asseturl = gameversion.url; // gameclient.js needs to access this
 


### PR DESCRIPTION
Simply, the cache folders are renamed to keep the client from redownloading all the assets.
A dotfile in the user directory is used to keep track of which version was last launched, which is used to rename the FusionFall folder back to whatever version corresponds to it.