### PR TITLE
Improved server address processing

### DIFF
--- a/assets/js/serverselector.js
+++ b/assets/js/serverselector.js
@@ -155,7 +155,19 @@ function setGameInfo(serverUUID) {
   window.asseturl = gameversion.url; // gameclient.js needs to access this
 
   remotefs.writeFileSync(__dirname+"\\assetInfo.php", asseturl);
-  remotefs.writeFileSync(__dirname+"\\loginInfo.php", result.ip);
+
+  // Server address parsing
+  var address;
+  var port;
+  var sepPos = result.ip.indexOf(":");
+  if (sepPos > -1) {
+    address = result.ip.substr(0, sepPos);
+    port = result.ip.substr(sepPos + 1);
+  } else {
+    address = result.ip
+    port = 23000 // default
+  }
+  remotefs.writeFileSync(__dirname+"\\loginInfo.php", address + ":" + port);
 
   if (result.hasOwnProperty('endpoint')) {
     var httpendpoint = result.endpoint.replace("https://", "http://")

--- a/assets/js/serverselector.js
+++ b/assets/js/serverselector.js
@@ -1,5 +1,6 @@
 var remote = require("remote");
 var remotefs = remote.require('fs-extra');
+var dns = remote.require('dns');
 
 var userdir = remote.require('app').getPath('userData');
 var versionarray
@@ -167,22 +168,35 @@ function setGameInfo(serverUUID) {
     address = result.ip
     port = 23000 // default
   }
-  remotefs.writeFileSync(__dirname+"\\loginInfo.php", address + ":" + port);
 
-  if (result.hasOwnProperty('endpoint')) {
-    var httpendpoint = result.endpoint.replace("https://", "http://")
-    remotefs.writeFileSync(__dirname+"\\rankurl.txt", httpendpoint+"getranks");
-    // Write these out too
-    remotefs.writeFileSync(__dirname+"\\sponsor.php", httpendpoint+"upsell/sponsor.png");
-    remotefs.writeFileSync(__dirname+"\\images.php", httpendpoint+"upsell/");
-  } else {
-    // Remove/default the endpoint related stuff, this server won't be using it
-    if (remotefs.existsSync(__dirname+"\\rankurl.txt")) {
-      remotefs.unlinkSync(__dirname+"\\rankurl.txt");
-      remotefs.writeFileSync(__dirname+"\\sponsor.php", "assets/img/welcome.png");
-      remotefs.writeFileSync(__dirname+"\\images.php", "assets/img/");
+  // DNS resolution. there is no synchronous version unfortunately
+  // if the resolution fails, keep the original entry (includes plain IP cases)
+  var ip = address;
+  dns.resolve4(address, function(err, res) {
+    if(!err) {
+      ip = res[0];
+      console.log("Resolved " + address + " to " + ip);
     }
-  }
+
+    var fullAddress = ip + ":" + port;
+    console.log("Will connect to " + fullAddress);
+    remotefs.writeFileSync(__dirname+"\\loginInfo.php", fullAddress);
+
+    if (result.hasOwnProperty('endpoint')) {
+      var httpendpoint = result.endpoint.replace("https://", "http://")
+      remotefs.writeFileSync(__dirname+"\\rankurl.txt", httpendpoint+"getranks");
+      // Write these out too
+      remotefs.writeFileSync(__dirname+"\\sponsor.php", httpendpoint+"upsell/sponsor.png");
+      remotefs.writeFileSync(__dirname+"\\images.php", httpendpoint+"upsell/");
+    } else {
+      // Remove/default the endpoint related stuff, this server won't be using it
+      if (remotefs.existsSync(__dirname+"\\rankurl.txt")) {
+        remotefs.unlinkSync(__dirname+"\\rankurl.txt");
+        remotefs.writeFileSync(__dirname+"\\sponsor.php", "assets/img/welcome.png");
+        remotefs.writeFileSync(__dirname+"\\images.php", "assets/img/");
+      }
+    }
+  });
 }
 
 // Returns the UUID of the server with the selected background color.


### PR DESCRIPTION
Two things:
- Address and port are now parsed separately, so you can leave out the port number and it'll default to 23000.
- Address is now resolved by Node's native `dns` module, so you can connect by domain name now. Plain IPs still work!

Resolves #15 and resolves #14 